### PR TITLE
Migrate to nf schema

### DIFF
--- a/assets/schema_input.json
+++ b/assets/schema_input.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/nf-cmgg/germline/master/assets/schema_input.json",
     "title": "Samplesheet validation schema",
     "description": "Schema for the samplesheet used in this pipeline",

--- a/nextflow.config
+++ b/nextflow.config
@@ -107,10 +107,6 @@ params {
     max_time                   = '240.h'
 
     // Schema validation default options
-    validationFailUnrecognisedParams = false
-    validationLenientMode            = false
-    validationSchemaIgnoreParams     = 'genomes,igenomes_base,test_data'
-    validationShowHiddenParams       = false
     validate_params                  = true
 
 }
@@ -250,7 +246,14 @@ singularity.registry = 'quay.io'
 
 // Nextflow plugins
 plugins {
-    id 'nf-validation@1.1.3' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+    id 'nf-schema@2.0.0' // Validation of pipeline parameters and creation of an input channel from a sample sheet
+}
+
+validation {
+    failUnrecognisedParams = false
+    lenientMode            = false
+    defaultIgnoreParams    = ['genomes','igenomes_base','test_data']
+    showHiddenParams       = false
 }
 
 // Load igenomes.config if required

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -1,10 +1,10 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
     "$id": "https://raw.githubusercontent.com/nf-cmgg/germline/master/nextflow_schema.json",
     "title": "nf-cmgg/germline pipeline parameters",
     "description": "A nextflow pipeline for calling and annotating variants",
     "type": "object",
-    "definitions": {
+    "defs": {
         "input_output_options": {
             "title": "Input/output options",
             "type": "object",
@@ -682,25 +682,25 @@
     },
     "allOf": [
         {
-            "$ref": "#/definitions/input_output_options"
+            "$ref": "#/defs/input_output_options"
         },
         {
-            "$ref": "#/definitions/reference_genome_options"
+            "$ref": "#/defs/reference_genome_options"
         },
         {
-            "$ref": "#/definitions/pipeline_specific_parameters"
+            "$ref": "#/defs/pipeline_specific_parameters"
         },
         {
-            "$ref": "#/definitions/institutional_config_options"
+            "$ref": "#/defs/institutional_config_options"
         },
         {
-            "$ref": "#/definitions/max_job_request_options"
+            "$ref": "#/defs/max_job_request_options"
         },
         {
-            "$ref": "#/definitions/generic_options"
+            "$ref": "#/defs/generic_options"
         },
         {
-            "$ref": "#/definitions/annotation_parameters"
+            "$ref": "#/defs/annotation_parameters"
         }
     ]
 }

--- a/subworkflows/local/utils_cmgg_germline_pipeline/main.nf
+++ b/subworkflows/local/utils_cmgg_germline_pipeline/main.nf
@@ -10,7 +10,7 @@
 
 include { UTILS_NFVALIDATION_PLUGIN } from '../../nf-core/utils_nfvalidation_plugin'
 include { paramsSummaryMap          } from 'plugin/nf-validation'
-include { fromSamplesheet           } from 'plugin/nf-validation'
+include { samplesheetToList         } from 'plugin/nf-validation'
 include { UTILS_NEXTFLOW_PIPELINE   } from '../../nf-core/utils_nextflow_pipeline'
 include { completionEmail           } from '../../nf-core/utils_nfcore_pipeline'
 include { completionSummary         } from '../../nf-core/utils_nfcore_pipeline'
@@ -84,7 +84,7 @@ workflow PIPELINE_INITIALISATION {
     // Output the samplesheet
     file(params.input).copyTo("${params.outdir}/samplesheet.csv")
 
-    Channel.fromSamplesheet("input")
+    Channel.fromList(samplesheetToList(params.input, "assets/schema_input.json"))
         .map { meta, cram, crai, gvcf, tbi, roi, ped, truth_vcf, truth_tbi, truth_bed ->
             // Infer the family ID from the PED file if no family ID was given.
             // If no PED is given, use the sample ID as family ID

--- a/subworkflows/local/utils_cmgg_germline_pipeline/main.nf
+++ b/subworkflows/local/utils_cmgg_germline_pipeline/main.nf
@@ -9,8 +9,8 @@
 */
 
 include { UTILS_NFVALIDATION_PLUGIN } from '../../nf-core/utils_nfvalidation_plugin'
-include { paramsSummaryMap          } from 'plugin/nf-validation'
-include { samplesheetToList         } from 'plugin/nf-validation'
+include { paramsSummaryMap          } from 'plugin/nf-schema'
+include { samplesheetToList         } from 'plugin/nf-schema'
 include { UTILS_NEXTFLOW_PIPELINE   } from '../../nf-core/utils_nextflow_pipeline'
 include { completionEmail           } from '../../nf-core/utils_nfcore_pipeline'
 include { completionSummary         } from '../../nf-core/utils_nfcore_pipeline'

--- a/subworkflows/nf-core/utils_nfvalidation_plugin/main.nf
+++ b/subworkflows/nf-core/utils_nfvalidation_plugin/main.nf
@@ -8,9 +8,9 @@
 ========================================================================================
 */
 
-include { paramsHelp         } from 'plugin/nf-validation'
-include { paramsSummaryLog   } from 'plugin/nf-validation'
-include { validateParameters } from 'plugin/nf-validation'
+include { paramsHelp         } from 'plugin/nf-schema'
+include { paramsSummaryLog   } from 'plugin/nf-schema'
+include { validateParameters } from 'plugin/nf-schema'
 
 /*
 ========================================================================================

--- a/workflows/germline.nf
+++ b/workflows/germline.nf
@@ -53,7 +53,7 @@ ch_multiqc_logo     = params.multiqc_logo   ? file(params.multiqc_logo, checkIfE
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-include { paramsSummaryMap                  } from 'plugin/nf-validation'
+include { paramsSummaryMap                  } from 'plugin/nf-schema'
 include { paramsSummaryMultiqc              } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { softwareVersionsToYAML            } from '../subworkflows/nf-core/utils_nfcore_pipeline'
 include { methodsDescriptionText            } from '../subworkflows/local/utils_cmgg_germline_pipeline'


### PR DESCRIPTION
A PR that migrates the old `nf-validation` plugin to the new `nf-schema` plugin